### PR TITLE
Fix insert bug. Where ith_node.left was wrong.

### DIFF
--- a/ds/cdll.py
+++ b/ds/cdll.py
@@ -538,12 +538,12 @@ class CDLList(MutableSequence[T]):
             return
         
         ith_node = self.peek(index, node=True, errors='raise')
-        ith_node.left.right = Node(
+        ith_node.left.right = node = Node(
             value, 
             left=ith_node.left, 
             right=ith_node
         )
-        ith_node.left = ith_node.right
+        ith_node.left = node
         self.size += 1
 
     def appendleft(self, value: T):


### PR DESCRIPTION
CDLList.insert had a bug, where it  was:
`ith_node.left = ith_node.right`

Which is wrong, it should have been the newly created Node in the right hand side. This apparently showed no issue while iterating in forward, but would go into an infinite loop if looped in reversed. Changed it to:

`ith_node.left = node`
